### PR TITLE
[codex] Add native surface defect detector

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,8 +6,8 @@ name: .NET
 on:
   push:
     branches: [ "master","develop" ]
-  # pull_request:
-    # branches: [ "master" ]
+  pull_request:
+    branches: [ "master","develop" ]
 
 jobs:
   build:
@@ -16,23 +16,29 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
-        
+
     - name: Restore dependencies
-      run: dotnet restore build.sln 
-      
+      run: |
+        dotnet restore build.sln
+        dotnet restore Test/ColorVision.UI.Tests/ColorVision.UI.Tests.csproj -p:Platform=x64
+
     - name: Setup MSBuild path
       uses: microsoft/setup-msbuild@v3
-    
-    - name: Build C++ project with MSBuild
+
+    - name: Build solution with MSBuild
       run: |
         msbuild build.sln /p:Configuration=Release /p:Platform=x64
-        
+
+    - name: Run .NET tests
+      run: dotnet test Test/ColorVision.UI.Tests/ColorVision.UI.Tests.csproj -c Release -p:Platform=x64 --no-restore --verbosity minimal
+
     - name: Publish to NuGet
+      if: github.event_name == 'push'
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -49,9 +55,3 @@ jobs:
         dotnet nuget push .\UI\ColorVision.UI.Desktop\bin\x64\Release\*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
         dotnet nuget push .\Engine\ColorVision.FileIO\bin\x64\Release\*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
         dotnet nuget push .\Engine\cvColorVision\bin\x64\Release\*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-        
-        
-
-
-
-      

--- a/ColorVision/Copilot/CopilotSettingsViewModel.cs
+++ b/ColorVision/Copilot/CopilotSettingsViewModel.cs
@@ -313,6 +313,7 @@ namespace ColorVision.Copilot
             {
                 if (SetProperty(ref _mcpPort, value))
                 {
+                    SyncMcpPortTextFromValue(value);
                     McpEndpoint = BuildMcpEndpoint();
                     MarkMcpSettingsPending();
                 }
@@ -330,6 +331,16 @@ namespace ColorVision.Copilot
             }
         }
         private string _mcpPortText = CopilotConfig.DefaultMcpPort.ToString(CultureInfo.InvariantCulture);
+
+        private void SyncMcpPortTextFromValue(int port)
+        {
+            var portText = port.ToString(CultureInfo.InvariantCulture);
+            if (string.Equals(_mcpPortText, portText, StringComparison.Ordinal))
+                return;
+
+            _mcpPortText = portText;
+            OnPropertyChanged(nameof(McpPortText));
+        }
 
         public bool IsMcpPortValid
         {

--- a/Native/include/opencv_media_export.h
+++ b/Native/include/opencv_media_export.h
@@ -89,6 +89,10 @@ extern "C" COLORVISIONCORE_API int M_FindLightBeads(HImage img, RoiRect roi, con
 
 extern "C" COLORVISIONCORE_API int M_DetectKeyRegions(HImage img, RoiRect roi, const char* config, char** result);
 
+// Surface defect / mura detector.
+// Returns JSON with summary + defect list. Thresholds are relative ratios; values > 1 are treated as percentages.
+extern "C" COLORVISIONCORE_API int M_DetectSurfaceDefects(HImage img, RoiRect roi, const char* config, char** result);
+
 extern "C" COLORVISIONCORE_API int FreeResult(char* result);
 
 extern "C" COLORVISIONCORE_API int M_CalSFR(

--- a/Native/opencv_helper/algorithm/surface_defect/surface_defect.cpp
+++ b/Native/opencv_helper/algorithm/surface_defect/surface_defect.cpp
@@ -1,0 +1,338 @@
+#include "surface_defect.h"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+
+namespace cvcore {
+namespace surface_defect {
+
+namespace {
+
+int normalizedOddKernel(int value)
+{
+    if (value <= 1) {
+        return 0;
+    }
+
+    return (value % 2 == 0) ? value + 1 : value;
+}
+
+std::vector<int> normalizedScales(const std::vector<int>& scales)
+{
+    std::vector<int> output;
+    output.reserve(scales.size());
+    for (int scale : scales) {
+        int normalized = normalizedOddKernel(scale);
+        if (normalized > 1) {
+            output.push_back(normalized);
+        }
+    }
+
+    if (output.empty()) {
+        output = { 31, 61, 121 };
+    }
+
+    std::sort(output.begin(), output.end());
+    output.erase(std::unique(output.begin(), output.end()), output.end());
+    return output;
+}
+
+cv::Mat selectAnalysisChannel(const cv::Mat& image, int channel)
+{
+    if (image.empty()) {
+        return {};
+    }
+
+    cv::Mat gray;
+    if (image.channels() == 1) {
+        gray = image;
+    }
+    else if (channel >= 0 && channel < image.channels()) {
+        cv::extractChannel(image, gray, channel);
+    }
+    else if (image.channels() == 3) {
+        cv::cvtColor(image, gray, cv::COLOR_BGR2GRAY);
+    }
+    else if (image.channels() == 4) {
+        cv::cvtColor(image, gray, cv::COLOR_BGRA2GRAY);
+    }
+
+    return gray;
+}
+
+bool convertToAnalysisFloat(const cv::Mat& image, int channel, cv::Mat& gray32)
+{
+    cv::Mat gray = selectAnalysisChannel(image, channel);
+    if (gray.empty()) {
+        return false;
+    }
+
+    double scale = 1.0;
+    switch (gray.depth())
+    {
+    case CV_8U:
+        scale = 1.0 / 255.0;
+        break;
+    case CV_16U:
+        scale = 1.0 / 65535.0;
+        break;
+    case CV_32F:
+    case CV_64F:
+        scale = 1.0;
+        break;
+    default:
+        return false;
+    }
+
+    gray.convertTo(gray32, CV_32F, scale);
+    cv::patchNaNs(gray32, 0.0);
+    return !gray32.empty();
+}
+
+void buildSignedRelativeDelta(const cv::Mat& source32, int scale, cv::Mat& delta)
+{
+    cv::Mat background;
+    cv::GaussianBlur(source32, background, cv::Size(scale, scale), 0.0, 0.0, cv::BORDER_REPLICATE);
+
+    cv::Mat denominator;
+    cv::absdiff(background, cv::Scalar::all(0.0), denominator);
+    cv::Mat epsilon(denominator.size(), denominator.type(), cv::Scalar::all(1e-6));
+    cv::max(denominator, epsilon, denominator);
+
+    cv::subtract(source32, background, delta);
+    cv::divide(delta, denominator, delta);
+}
+
+void thresholdResidual(const cv::Mat& residual, double threshold, int openKernel, int closeKernel, cv::Mat& mask)
+{
+    cv::threshold(residual, mask, threshold, 255.0, cv::THRESH_BINARY);
+    mask.convertTo(mask, CV_8U);
+
+    int openSize = normalizedOddKernel(openKernel);
+    if (openSize > 1) {
+        cv::Mat kernel = cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(openSize, openSize));
+        cv::morphologyEx(mask, mask, cv::MORPH_OPEN, kernel);
+    }
+
+    int closeSize = normalizedOddKernel(closeKernel);
+    if (closeSize > 1) {
+        cv::Mat kernel = cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(closeSize, closeSize));
+        cv::morphologyEx(mask, mask, cv::MORPH_CLOSE, kernel);
+    }
+}
+
+double aspectRatio(const cv::Rect& rect)
+{
+    const int minSide = std::max(1, std::min(rect.width, rect.height));
+    const int maxSide = std::max(rect.width, rect.height);
+    return static_cast<double>(maxSide) / static_cast<double>(minSide);
+}
+
+std::string gradeForSeverity(double severity, const SurfaceDefectConfig& config)
+{
+    if (severity >= config.criticalSeverity) {
+        return "critical";
+    }
+    if (severity >= config.majorSeverity) {
+        return "major";
+    }
+    if (severity >= config.minorSeverity) {
+        return "minor";
+    }
+    return severity > 0.0 ? "trace" : "ok";
+}
+
+std::string classifyDefect(const std::string& polarity, int area, double aspect, int scale, const SurfaceDefectConfig& config)
+{
+    if (config.enableLineDetect && aspect >= config.lineAspectRatio) {
+        return polarity == "bright" ? "brightLine" : "darkLine";
+    }
+
+    if (area >= config.muraMinArea || scale >= 61) {
+        return polarity == "bright" ? "brightMura" : "darkMura";
+    }
+
+    return polarity == "bright" ? "brightSpot" : "darkSpot";
+}
+
+bool rectsTouchOrOverlap(const cv::Rect& a, const cv::Rect& b, int distance)
+{
+    cv::Rect expanded(
+        a.x - distance,
+        a.y - distance,
+        a.width + distance * 2,
+        a.height + distance * 2);
+    return (expanded & b).area() > 0;
+}
+
+void appendComponents(
+    const cv::Mat& signedDelta,
+    const cv::Mat& mask,
+    const std::string& polarity,
+    int scale,
+    const SurfaceDefectConfig& config,
+    std::vector<SurfaceDefectItem>& defects)
+{
+    cv::Mat labels;
+    cv::Mat stats;
+    cv::Mat centroids;
+    const int labelCount = cv::connectedComponentsWithStats(mask, labels, stats, centroids, 8, CV_32S);
+
+    for (int label = 1; label < labelCount; ++label) {
+        const int area = stats.at<int>(label, cv::CC_STAT_AREA);
+        if (area < config.minArea || (config.maxArea > 0 && area > config.maxArea)) {
+            continue;
+        }
+
+        const cv::Rect rect(
+            stats.at<int>(label, cv::CC_STAT_LEFT),
+            stats.at<int>(label, cv::CC_STAT_TOP),
+            stats.at<int>(label, cv::CC_STAT_WIDTH),
+            stats.at<int>(label, cv::CC_STAT_HEIGHT));
+        if (rect.width <= 0 || rect.height <= 0) {
+            continue;
+        }
+
+        cv::Mat componentMask;
+        cv::compare(labels, label, componentMask, cv::CMP_EQ);
+
+        cv::Scalar mean = cv::mean(signedDelta, componentMask);
+        double minDelta = 0.0;
+        double maxDelta = 0.0;
+        cv::minMaxLoc(signedDelta, &minDelta, &maxDelta, nullptr, nullptr, componentMask);
+
+        const double maxDeltaAbs = std::max(std::abs(minDelta), std::abs(maxDelta));
+        const double severity = maxDeltaAbs * std::sqrt(static_cast<double>(area));
+        if (severity < config.minSeverity) {
+            continue;
+        }
+
+        const double aspect = aspectRatio(rect);
+        SurfaceDefectItem item;
+        item.scale = scale;
+        item.polarity = polarity;
+        item.boundingRect = rect;
+        item.center = cv::Point2d(centroids.at<double>(label, 0), centroids.at<double>(label, 1));
+        item.area = area;
+        item.meanDelta = mean[0];
+        item.minDelta = minDelta;
+        item.maxDelta = maxDelta;
+        item.maxDeltaAbs = maxDeltaAbs;
+        item.severity = severity;
+        item.aspectRatio = aspect;
+        item.fillRatio = static_cast<double>(area) / static_cast<double>(std::max(1, rect.area()));
+        item.type = classifyDefect(polarity, area, aspect, scale, config);
+        defects.push_back(std::move(item));
+    }
+}
+
+std::vector<SurfaceDefectItem> mergeDefects(std::vector<SurfaceDefectItem> defects, const SurfaceDefectConfig& config)
+{
+    std::sort(defects.begin(), defects.end(), [](const auto& a, const auto& b) {
+        return a.severity > b.severity;
+    });
+
+    std::vector<SurfaceDefectItem> selected;
+    selected.reserve(defects.size());
+    for (const SurfaceDefectItem& defect : defects) {
+        bool duplicate = false;
+        for (const SurfaceDefectItem& existing : selected) {
+            if (defect.polarity == existing.polarity &&
+                rectsTouchOrOverlap(defect.boundingRect, existing.boundingRect, config.mergeDistance)) {
+                duplicate = true;
+                break;
+            }
+        }
+
+        if (duplicate) {
+            continue;
+        }
+
+        selected.push_back(defect);
+        if (config.maxDefects > 0 && static_cast<int>(selected.size()) >= config.maxDefects) {
+            break;
+        }
+    }
+
+    std::sort(selected.begin(), selected.end(), [](const auto& a, const auto& b) {
+        if (a.boundingRect.y != b.boundingRect.y) {
+            return a.boundingRect.y < b.boundingRect.y;
+        }
+        return a.boundingRect.x < b.boundingRect.x;
+    });
+
+    for (int i = 0; i < static_cast<int>(selected.size()); ++i) {
+        selected[static_cast<size_t>(i)].id = i + 1;
+    }
+
+    return selected;
+}
+
+SurfaceDefectSummary summarize(const std::vector<SurfaceDefectItem>& defects, const SurfaceDefectConfig& config)
+{
+    SurfaceDefectSummary summary;
+    summary.defectCount = static_cast<int>(defects.size());
+    double totalSeverity = 0.0;
+    for (const SurfaceDefectItem& defect : defects) {
+        if (defect.polarity == "dark") {
+            summary.darkCount++;
+        }
+        else if (defect.polarity == "bright") {
+            summary.brightCount++;
+        }
+
+        summary.maxSeverity = std::max(summary.maxSeverity, defect.severity);
+        totalSeverity += defect.severity;
+    }
+
+    summary.meanSeverity = defects.empty() ? 0.0 : totalSeverity / static_cast<double>(defects.size());
+    summary.grade = gradeForSeverity(summary.maxSeverity, config);
+    return summary;
+}
+
+} // namespace
+
+SurfaceDefectResult detectSurfaceDefects(const cv::Mat& image, const SurfaceDefectConfig& config)
+{
+    SurfaceDefectResult result;
+    result.imageSize = image.empty() ? cv::Size() : cv::Size(image.cols, image.rows);
+
+    cv::Mat source32;
+    if (!convertToAnalysisFloat(image, config.channel, source32)) {
+        result.statusCode = "invalid_image";
+        result.message = "Invalid image or unsupported channel count/depth.";
+        return result;
+    }
+
+    std::vector<SurfaceDefectItem> defects;
+    const std::vector<int> scales = normalizedScales(config.scales);
+    for (int scale : scales) {
+        cv::Mat delta;
+        buildSignedRelativeDelta(source32, scale, delta);
+
+        if (config.enableBright && config.brightThreshold > 0.0) {
+            cv::Mat brightMask;
+            thresholdResidual(delta, config.brightThreshold, config.openKernel, config.closeKernel, brightMask);
+            appendComponents(delta, brightMask, "bright", scale, config, defects);
+        }
+
+        if (config.enableDark && config.darkThreshold > 0.0) {
+            cv::Mat darkResidual;
+            cv::multiply(delta, -1.0, darkResidual);
+            cv::Mat darkMask;
+            thresholdResidual(darkResidual, config.darkThreshold, config.openKernel, config.closeKernel, darkMask);
+            appendComponents(delta, darkMask, "dark", scale, config, defects);
+        }
+    }
+
+    result.defects = mergeDefects(std::move(defects), config);
+    result.summary = summarize(result.defects, config);
+    result.success = true;
+    result.statusCode = "ok";
+    result.message = result.defects.empty() ? "No surface defects detected." : "ok";
+    return result;
+}
+
+} // namespace surface_defect
+} // namespace cvcore

--- a/Native/opencv_helper/algorithm/surface_defect/surface_defect.h
+++ b/Native/opencv_helper/algorithm/surface_defect/surface_defect.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <opencv2/opencv.hpp>
+#include <string>
+#include <vector>
+
+namespace cvcore {
+namespace surface_defect {
+
+struct SurfaceDefectConfig
+{
+    int channel = -1;
+    std::vector<int> scales = { 31, 61, 121 };
+    double darkThreshold = 0.015;
+    double brightThreshold = 0.015;
+    int minArea = 8;
+    int maxArea = 200000;
+    int muraMinArea = 1000;
+    int openKernel = 1;
+    int closeKernel = 3;
+    int mergeDistance = 3;
+    int maxDefects = 1000;
+    bool enableDark = true;
+    bool enableBright = true;
+    bool enableLineDetect = true;
+    double lineAspectRatio = 8.0;
+    double minSeverity = 0.0;
+    double minorSeverity = 0.25;
+    double majorSeverity = 1.0;
+    double criticalSeverity = 3.0;
+};
+
+struct SurfaceDefectItem
+{
+    int id = 0;
+    int scale = 0;
+    std::string type;
+    std::string polarity;
+    cv::Rect boundingRect;
+    cv::Point2d center;
+    int area = 0;
+    double meanDelta = 0.0;
+    double minDelta = 0.0;
+    double maxDelta = 0.0;
+    double maxDeltaAbs = 0.0;
+    double severity = 0.0;
+    double aspectRatio = 0.0;
+    double fillRatio = 0.0;
+};
+
+struct SurfaceDefectSummary
+{
+    int defectCount = 0;
+    int darkCount = 0;
+    int brightCount = 0;
+    double maxSeverity = 0.0;
+    double meanSeverity = 0.0;
+    std::string grade = "ok";
+};
+
+struct SurfaceDefectResult
+{
+    bool success = false;
+    std::string statusCode = "not_run";
+    std::string message;
+    cv::Size imageSize;
+    std::vector<SurfaceDefectItem> defects;
+    SurfaceDefectSummary summary;
+};
+
+SurfaceDefectResult detectSurfaceDefects(const cv::Mat& image, const SurfaceDefectConfig& config);
+
+} // namespace surface_defect
+} // namespace cvcore

--- a/Native/opencv_helper/opencv_helper.vcxproj
+++ b/Native/opencv_helper/opencv_helper.vcxproj
@@ -194,6 +194,7 @@
     <ClInclude Include="algorithm\distortion\distortion_p9.h" />
     <ClInclude Include="algorithm\sfr\sfr_bmw4.h" />
     <ClInclude Include="algorithm\sfr\sfr_slanted.h" />
+    <ClInclude Include="algorithm\surface_defect\surface_defect.h" />
     <ClInclude Include="framework.h" />
     <ClInclude Include="include\cvcore\sfr.h" />
     <ClInclude Include="native_log.h" />
@@ -205,6 +206,7 @@
     <ClCompile Include="algorithm\distortion\distortion_p9.cpp" />
     <ClCompile Include="algorithm\sfr\sfr_bmw4.cpp" />
     <ClCompile Include="algorithm\sfr\sfr_slanted.cpp" />
+    <ClCompile Include="algorithm\surface_defect\surface_defect.cpp" />
     <ClCompile Include="common.cpp" />
     <ClCompile Include="exports\sfr_export.cpp" />
     <ClCompile Include="native_log.cpp" />

--- a/Native/opencv_helper/opencv_helper.vcxproj.filters
+++ b/Native/opencv_helper/opencv_helper.vcxproj.filters
@@ -28,6 +28,9 @@
     <Filter Include="算法\Distortion">
       <UniqueIdentifier>{62a9db2d-8111-48fa-b1e4-7394f6fe7b9f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="算法\SurfaceDefect">
+      <UniqueIdentifier>{08a7b7d1-04ab-4b7a-a654-2f35546c4f92}</UniqueIdentifier>
+    </Filter>
     <Filter Include="导出">
       <UniqueIdentifier>{a1b2c3d4-1234-5678-9abc-def012345678}</UniqueIdentifier>
     </Filter>
@@ -69,6 +72,9 @@
     <ClInclude Include="algorithm\distortion\distortion_p9.h">
       <Filter>算法\Distortion</Filter>
     </ClInclude>
+    <ClInclude Include="algorithm\surface_defect\surface_defect.h">
+      <Filter>算法\SurfaceDefect</Filter>
+    </ClInclude>
     <ClInclude Include="include\cvcore\sfr.h">
       <Filter>接口</Filter>
     </ClInclude>
@@ -106,6 +112,9 @@
     </ClCompile>
     <ClCompile Include="algorithm\distortion\distortion_p9.cpp">
       <Filter>算法\Distortion</Filter>
+    </ClCompile>
+    <ClCompile Include="algorithm\surface_defect\surface_defect.cpp">
+      <Filter>算法\SurfaceDefect</Filter>
     </ClCompile>
     <ClCompile Include="exports\sfr_export.cpp">
       <Filter>导出</Filter>

--- a/Native/opencv_helper/opencv_media_export.cpp
+++ b/Native/opencv_helper/opencv_media_export.cpp
@@ -4,13 +4,16 @@
 #include "algorithm.h"
 #include "algorithm/distortion/distortion_p9.h"
 #include "algorithm/sfr/sfr_bmw4.h"
+#include "algorithm/surface_defect/surface_defect.h"
 #include <opencv2/opencv.hpp>
 #include <nlohmann\json.hpp>
+#include <algorithm>
 #include <string>
 #include <locale>
 #include <codecvt>
 #include <cmath>
 #include <combaseapi.h>
+#include <cctype>
 #include <cstring>
 #include <exception>
 #include <future>
@@ -207,6 +210,115 @@ cvcore::distortion::DistortionP9Config ParseDistortionP9Config(const json& root)
 	return config;
 }
 
+double ReadRatioValue(const json& root, const char* lowerName, const char* upperName, double fallback)
+{
+	double value = root.value(lowerName, root.value(upperName, fallback));
+	return value > 1.0 ? value / 100.0 : value;
+}
+
+std::vector<int> ReadIntArray(const json& root, const char* lowerName, const char* upperName, const std::vector<int>& fallback)
+{
+	const json* value = nullptr;
+	if (root.contains(lowerName) && root.at(lowerName).is_array()) {
+		value = &root.at(lowerName);
+	}
+	else if (root.contains(upperName) && root.at(upperName).is_array()) {
+		value = &root.at(upperName);
+	}
+
+	if (value == nullptr) {
+		return fallback;
+	}
+
+	std::vector<int> output;
+	output.reserve(value->size());
+	for (const auto& item : *value) {
+		if (item.is_number_integer()) {
+			output.push_back(item.get<int>());
+		}
+	}
+
+	return output.empty() ? fallback : output;
+}
+
+int ReadSurfaceDefectChannel(const json& root, int fallback)
+{
+	if (root.contains("channel")) {
+		const json& value = root.at("channel");
+		if (value.is_number_integer()) {
+			return value.get<int>();
+		}
+		if (value.is_string()) {
+			std::string channel = value.get<std::string>();
+			std::transform(channel.begin(), channel.end(), channel.begin(), [](unsigned char c) {
+				return static_cast<char>(std::tolower(c));
+			});
+			if (channel == "b" || channel == "blue") return 0;
+			if (channel == "g" || channel == "green") return 1;
+			if (channel == "r" || channel == "red") return 2;
+			return -1;
+		}
+	}
+	if (root.contains("Channel") && root.at("Channel").is_number_integer()) {
+		return root.at("Channel").get<int>();
+	}
+	return fallback;
+}
+
+cvcore::surface_defect::SurfaceDefectConfig ParseSurfaceDefectConfig(const json& root)
+{
+	cvcore::surface_defect::SurfaceDefectConfig config;
+	if (!root.is_object()) {
+		return config;
+	}
+
+	config.channel = ReadSurfaceDefectChannel(root, config.channel);
+	config.scales = ReadIntArray(root, "scales", "Scales", config.scales);
+	config.darkThreshold = ReadRatioValue(root, "darkThreshold", "DarkThreshold", config.darkThreshold);
+	config.brightThreshold = ReadRatioValue(root, "brightThreshold", "BrightThreshold", config.brightThreshold);
+	config.minArea = root.value("minArea", root.value("MinArea", config.minArea));
+	config.maxArea = root.value("maxArea", root.value("MaxArea", config.maxArea));
+	config.muraMinArea = root.value("muraMinArea", root.value("MuraMinArea", config.muraMinArea));
+	config.openKernel = root.value("openKernel", root.value("OpenKernel", config.openKernel));
+	config.closeKernel = root.value("closeKernel", root.value("CloseKernel", config.closeKernel));
+	config.mergeDistance = root.value("mergeDistance", root.value("MergeDistance", config.mergeDistance));
+	config.maxDefects = root.value("maxDefects", root.value("MaxDefects", config.maxDefects));
+	config.enableDark = root.value("enableDark", root.value("EnableDark", config.enableDark));
+	config.enableBright = root.value("enableBright", root.value("EnableBright", config.enableBright));
+	config.enableLineDetect = root.value("enableLineDetect", root.value("EnableLineDetect", config.enableLineDetect));
+	config.lineAspectRatio = root.value("lineAspectRatio", root.value("LineAspectRatio", config.lineAspectRatio));
+	config.minSeverity = root.value("minSeverity", root.value("MinSeverity", config.minSeverity));
+	config.minorSeverity = root.value("minorSeverity", root.value("MinorSeverity", config.minorSeverity));
+	config.majorSeverity = root.value("majorSeverity", root.value("MajorSeverity", config.majorSeverity));
+	config.criticalSeverity = root.value("criticalSeverity", root.value("CriticalSeverity", config.criticalSeverity));
+	return config;
+}
+
+json SurfaceDefectConfigToJson(const cvcore::surface_defect::SurfaceDefectConfig& config)
+{
+	return json{
+		{ "channel", config.channel },
+		{ "scales", config.scales },
+		{ "darkThreshold", config.darkThreshold },
+		{ "brightThreshold", config.brightThreshold },
+		{ "minArea", config.minArea },
+		{ "maxArea", config.maxArea },
+		{ "muraMinArea", config.muraMinArea },
+		{ "openKernel", config.openKernel },
+		{ "closeKernel", config.closeKernel },
+		{ "mergeDistance", config.mergeDistance },
+		{ "maxDefects", config.maxDefects },
+		{ "enableDark", config.enableDark },
+		{ "enableBright", config.enableBright },
+		{ "enableLineDetect", config.enableLineDetect },
+		{ "lineAspectRatio", config.lineAspectRatio },
+		{ "minSeverity", config.minSeverity },
+		{ "minorSeverity", config.minorSeverity },
+		{ "majorSeverity", config.majorSeverity },
+		{ "criticalSeverity", config.criticalSeverity }
+	};
+}
+
 json DistortionP9ConfigToJson(const cvcore::distortion::DistortionP9Config& config)
 {
 	return json{
@@ -307,6 +419,49 @@ json PointToJson(const cv::Point2d& point, const cv::Point& origin)
 	return json{
 		{ "x", point.x + origin.x },
 		{ "y", point.y + origin.y }
+	};
+}
+
+std::string SurfaceDefectGrade(double severity, const cvcore::surface_defect::SurfaceDefectConfig& config)
+{
+	if (severity >= config.criticalSeverity) {
+		return "critical";
+	}
+	if (severity >= config.majorSeverity) {
+		return "major";
+	}
+	if (severity >= config.minorSeverity) {
+		return "minor";
+	}
+	return severity > 0.0 ? "trace" : "ok";
+}
+
+json SurfaceDefectToJson(
+	const cvcore::surface_defect::SurfaceDefectItem& defect,
+	const cv::Point& origin,
+	const cvcore::surface_defect::SurfaceDefectConfig& config)
+{
+	return json{
+		{ "id", defect.id },
+		{ "type", defect.type },
+		{ "polarity", defect.polarity },
+		{ "grade", SurfaceDefectGrade(defect.severity, config) },
+		{ "scale", defect.scale },
+		{ "x", defect.boundingRect.x + origin.x },
+		{ "y", defect.boundingRect.y + origin.y },
+		{ "w", defect.boundingRect.width },
+		{ "h", defect.boundingRect.height },
+		{ "centerX", defect.center.x + origin.x },
+		{ "centerY", defect.center.y + origin.y },
+		{ "area", defect.area },
+		{ "meanDelta", defect.meanDelta },
+		{ "minDelta", defect.minDelta },
+		{ "maxDelta", defect.maxDelta },
+		{ "maxDeltaAbs", defect.maxDeltaAbs },
+		{ "severity", defect.severity },
+		{ "aspectRatio", defect.aspectRatio },
+		{ "fillRatio", defect.fillRatio },
+		{ "boundingRect", RectToJson(defect.boundingRect, origin) }
 	};
 }
 
@@ -1251,6 +1406,73 @@ COLORVISIONCORE_API int M_DetectKeyRegions(HImage img, RoiRect roi, const char* 
 		}
 		outputJson["KeyRegions"] = rectsArray;
 		outputJson["Count"] = keyRects.size();
+
+		return CopyJsonResult(outputJson, result);
+	});
+}
+
+COLORVISIONCORE_API int M_DetectSurfaceDefects(HImage img, RoiRect roi, const char* config, char** result)
+{
+	return GuardIntExport([&]() -> int {
+		if (result != nullptr) {
+			*result = nullptr;
+		}
+
+		cv::Mat mat = CreateMatView(img);
+		if (mat.empty() || result == nullptr) {
+			return ExportInvalidArgument;
+		}
+
+		json j = json::object();
+		if (config != nullptr && config[0] != '\0') {
+			if (!TryParseJson(config, j)) {
+				return ExportInvalidJson;
+			}
+		}
+
+		cv::Point origin(0, 0);
+		cv::Rect mroi(roi.x, roi.y, roi.width, roi.height);
+		const cv::Rect imageRect(0, 0, mat.cols, mat.rows);
+		const bool useRoi = (mroi.width > 0 && mroi.height > 0 && (mroi & imageRect) == mroi);
+		if (useRoi) {
+			mat = mat(mroi);
+			origin = cv::Point(mroi.x, mroi.y);
+		}
+
+		cvcore::surface_defect::SurfaceDefectConfig defectConfig = ParseSurfaceDefectConfig(j);
+		cvcore::surface_defect::SurfaceDefectResult calcResult =
+			cvcore::surface_defect::detectSurfaceDefects(mat, defectConfig);
+
+		json outputJson;
+		outputJson["algorithm"] = "SurfaceDefect";
+		outputJson["version"] = "0.1";
+		outputJson["success"] = calcResult.success;
+		outputJson["statusCode"] = calcResult.statusCode;
+		outputJson["message"] = calcResult.message;
+		outputJson["count"] = calcResult.defects.size();
+		outputJson["image"] = {
+			{ "width", img.cols },
+			{ "height", img.rows },
+			{ "roi", RectToJson(useRoi ? mroi : cv::Rect(0, 0, mat.cols, mat.rows), cv::Point(0, 0)) }
+		};
+		outputJson["configUsed"] = SurfaceDefectConfigToJson(defectConfig);
+		outputJson["summary"] = {
+			{ "defectCount", calcResult.summary.defectCount },
+			{ "darkCount", calcResult.summary.darkCount },
+			{ "brightCount", calcResult.summary.brightCount },
+			{ "maxSeverity", calcResult.summary.maxSeverity },
+			{ "meanSeverity", calcResult.summary.meanSeverity },
+			{ "grade", calcResult.summary.grade }
+		};
+		outputJson["diagnostics"] = {
+			{ "roiUsed", useRoi },
+			{ "relativeResidual", true },
+			{ "background", "gaussian" }
+		};
+		outputJson["defects"] = json::array();
+		for (const auto& defect : calcResult.defects) {
+			outputJson["defects"].push_back(SurfaceDefectToJson(defect, origin, defectConfig));
+		}
 
 		return CopyJsonResult(outputJson, result);
 	});

--- a/Test/ColorVision.UI.Tests/TreemapLayoutTests.cs
+++ b/Test/ColorVision.UI.Tests/TreemapLayoutTests.cs
@@ -1,5 +1,5 @@
 #pragma warning disable CA1707
-using ColorVision.UI.Controls;
+using ColorVision.UI.Desktop.ThirdPartyApps.Treemap;
 using System.Windows;
 
 namespace ColorVision.UI.Tests;

--- a/Test/opencv_helper_test/test_find_luminous_area.cpp
+++ b/Test/opencv_helper_test/test_find_luminous_area.cpp
@@ -893,6 +893,53 @@ bool smokeDistortionP9DesktopFixtureIfPresent()
     return ok;
 }
 
+bool smokeSurfaceDefectDetectsSyntheticBrightAndDark()
+{
+    cv::Mat image(160, 220, CV_8UC1, cv::Scalar(128));
+    cv::rectangle(image, cv::Rect(42, 46, 24, 18), cv::Scalar(190), cv::FILLED);
+    cv::rectangle(image, cv::Rect(142, 92, 28, 20), cv::Scalar(70), cv::FILLED);
+
+    HImage hImage = createHImageFromMat(image);
+    RoiRect roi = { 0, 0, 0, 0 };
+    json config = {
+        { "scales", { 31 } },
+        { "brightThreshold", 0.05 },
+        { "darkThreshold", 0.05 },
+        { "minArea", 20 },
+        { "muraMinArea", 2000 },
+        { "openKernel", 1 },
+        { "closeKernel", 3 },
+        { "mergeDistance", 5 }
+    };
+
+    char* result = nullptr;
+    int ret = M_DetectSurfaceDefects(hImage, roi, config.dump().c_str(), &result);
+    if (ret <= 0 || result == nullptr) {
+        return false;
+    }
+
+    json output = json::parse(result, nullptr, false);
+    FreeResult(result);
+    if (output.is_discarded() || !output.value("success", false)) {
+        return false;
+    }
+
+    const auto& summary = output.at("summary");
+    if (summary.value("brightCount", 0) < 1 || summary.value("darkCount", 0) < 1) {
+        return false;
+    }
+
+    bool hasBright = false;
+    bool hasDark = false;
+    for (const auto& defect : output.at("defects")) {
+        const std::string polarity = defect.value("polarity", "");
+        hasBright = hasBright || polarity == "bright";
+        hasDark = hasDark || polarity == "dark";
+    }
+
+    return hasBright && hasDark;
+}
+
 bool smokeConvertImageHandlesStrideAndOwnedBuffer()
 {
     const int width = 7;
@@ -1744,6 +1791,11 @@ int main(int argc, char* argv[])
 
     if (!smokeDistortionP9DesktopFixtureIfPresent()) {
         std::cerr << "M_CalDistortionP9 desktop fixture test failed" << std::endl;
+        return 1;
+    }
+
+    if (!smokeSurfaceDefectDetectsSyntheticBrightAndDark()) {
+        std::cerr << "M_DetectSurfaceDefects synthetic bright/dark test failed" << std::endl;
         return 1;
     }
 

--- a/UI/ColorVision.Core/OpenCVMediaHelper.cs
+++ b/UI/ColorVision.Core/OpenCVMediaHelper.cs
@@ -52,6 +52,9 @@ namespace ColorVision.Core
         [DllImport(LibPath, CallingConvention = CallingConvention.Cdecl)]
         public static extern int M_CalDistortionP9(HImage img, RoiRect roi, string config, out IntPtr result);
 
+        [DllImport(LibPath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int M_DetectSurfaceDefects(HImage img, RoiRect roi, string config, out IntPtr result);
+
 
         [DllImport(LibPath, CallingConvention = CallingConvention.Cdecl)]
         public static extern int FreeResult(IntPtr str);


### PR DESCRIPTION
## Summary

- Add a native `SurfaceDefect` / Mura detector with multi-scale background residuals, bright/dark component extraction, connected-component stats, severity grading, and JSON output.
- Export `M_DetectSurfaceDefects` through `opencv_helper.dll` and add the C# P/Invoke entry point.
- Add a synthetic native smoke test for bright/dark defect detection and restore CI coverage for the UI test project.

## Validation

- `dotnet test Test\ColorVision.UI.Tests\ColorVision.UI.Tests.csproj -p:Platform=x64 --no-restore --verbosity minimal` passed: 161 passed / 17 skipped.
- `dotnet build UI\ColorVision.Core\ColorVision.Core.csproj -p:Platform=x64 --no-restore --verbosity minimal` passed.
- `dotnet publish ColorVision\ColorVision.csproj -c Release -f net10.0-windows -p:Platform=x64 -p:ErrorOnDuplicatePublishOutputFiles=false --no-restore --verbosity minimal` passed and emitted `ColorVision\bin\x64\Release\net10.0-windows\publish\`.
- `git diff --check` reported only CRLF warnings.

## Notes

- Native `opencv_helper` compile/run could not be executed locally because this machine does not expose VS/MSBuild/cl in PATH or standard install paths.
- Publish emits existing `SQLitePCLRaw.lib.e_sqlite3` high-severity vulnerability warnings.
- Plain `dotnet publish` without `ErrorOnDuplicatePublishOutputFiles=false` hits an existing duplicate `ColorVision.ShellExtension.comhost.dll` publish-output conflict.