### PR TITLE
[codex] Add dynamic MTFHV058 result output

### DIFF
--- a/Projects/ProjectARVRPro/Exports/ObjectiveTestResultValueResolver.cs
+++ b/Projects/ProjectARVRPro/Exports/ObjectiveTestResultValueResolver.cs
@@ -22,6 +22,10 @@ namespace ProjectARVRPro.Exports
             if (dynamicItem != null)
                 return dynamicItem;
 
+            ObjectiveTestItem? mtf058Item = FindDynamicMTFHV058(testScreenName, itemName);
+            if (mtf058Item != null)
+                return mtf058Item;
+
             object? screen = FindScreenObject(testScreenName);
             return FindItem(screen, itemName);
         }
@@ -50,11 +54,24 @@ namespace ProjectARVRPro.Exports
                 string.Equals(item.Name, itemName, StringComparison.OrdinalIgnoreCase));
         }
 
+        private ObjectiveTestItem? FindDynamicMTFHV058(string testScreenName, string itemName)
+        {
+            if (_result.DynamicMTFHV058TestResults == null)
+                return null;
+
+            if (!_result.DynamicMTFHV058TestResults.TryGetValue(testScreenName, out var result))
+                return null;
+
+            return FindItem(result, itemName);
+        }
+
         private object? FindScreenObject(string testScreenName)
         {
             foreach (PropertyInfo property in typeof(ObjectiveTestResult).GetProperties(BindingFlags.Public | BindingFlags.Instance))
             {
-                if (property.Name == nameof(ObjectiveTestResult.DynamicTestResults))
+                if (property.Name == nameof(ObjectiveTestResult.DynamicTestResults) ||
+                    property.Name == nameof(ObjectiveTestResult.DynamicPoixyuvDatas) ||
+                    property.Name == nameof(ObjectiveTestResult.DynamicMTFHV058TestResults))
                     continue;
 
                 string displayName = property.GetCustomAttributes(false)

--- a/Projects/ProjectARVRPro/ObjectiveTestResult.cs
+++ b/Projects/ProjectARVRPro/ObjectiveTestResult.cs
@@ -55,6 +55,9 @@ namespace ProjectARVRPro
         [DisplayName("MTF058")]
         public List<MTFHV058TestResult> MTFHV058TestResults { get; set; } = new List<MTFHV058TestResult>();
 
+        [DisplayName("DynamicMTFHV058")]
+        public Dictionary<string, MTFHV058TestResult> DynamicMTFHV058TestResults { get; set; } = new Dictionary<string, MTFHV058TestResult>();
+
         [DisplayName("Distortion")]
         public DistortionTestResult DistortionTestResult { get; set; }
 

--- a/Projects/ProjectARVRPro/ObjectiveTestResultCsvExporter.cs
+++ b/Projects/ProjectARVRPro/ObjectiveTestResultCsvExporter.cs
@@ -93,7 +93,8 @@ namespace ProjectARVRPro
             {
                 // Skip dynamic dictionaries - handled separately below
                 if (prop.Name == nameof(ObjectiveTestResult.DynamicTestResults) ||
-                    prop.Name == nameof(ObjectiveTestResult.DynamicPoixyuvDatas))
+                    prop.Name == nameof(ObjectiveTestResult.DynamicPoixyuvDatas) ||
+                    prop.Name == nameof(ObjectiveTestResult.DynamicMTFHV058TestResults))
                     continue;
 
                 if (!prop.PropertyType.IsValueType && prop.PropertyType != typeof(string))
@@ -133,6 +134,15 @@ namespace ProjectARVRPro
                             rows.Add(FormatCsvRow(testScreenName, testItem.Name, testItem));
                         }
                     }
+                }
+            }
+
+            if (results.DynamicMTFHV058TestResults != null)
+            {
+                foreach (var kvp in results.DynamicMTFHV058TestResults)
+                {
+                    if (kvp.Value != null)
+                        CollectRows(kvp.Value, kvp.Key, rows);
                 }
             }
 

--- a/Projects/ProjectARVRPro/Process/MTF/MTFHV058/MTFHV058Process.cs
+++ b/Projects/ProjectARVRPro/Process/MTF/MTFHV058/MTFHV058Process.cs
@@ -251,7 +251,12 @@ namespace ProjectARVRPro.Process.MTF.MTFHV058
 
 
                 ctx.Result.ViewResultJson = JsonConvert.SerializeObject(testResult);
-                ctx.ObjectiveTestResult.MTFHV058TestResults.Add(JsonConvert.DeserializeObject<MTFHV058TestResult>(ctx.Result.ViewResultJson) ?? new MTFHV058TestResult());
+                MTFHV058TestResult objectiveResult = JsonConvert.DeserializeObject<MTFHV058TestResult>(ctx.Result.ViewResultJson) ?? new MTFHV058TestResult();
+                string outputName = GetOutputName();
+                if (string.IsNullOrWhiteSpace(outputName))
+                    ctx.ObjectiveTestResult.MTFHV058TestResults.Add(objectiveResult);
+                else
+                    ctx.ObjectiveTestResult.DynamicMTFHV058TestResults[outputName] = objectiveResult;
                 return true;
             }
             catch (Exception ex)
@@ -319,6 +324,11 @@ namespace ProjectARVRPro.Process.MTF.MTFHV058
         public override IRecipeConfig GetRecipeConfig()
         {
             return RecipeManager.GetInstance().RecipeConfig.GetRequiredService<MTFHV058RecipeConfig>();
+        }
+
+        private string GetOutputName()
+        {
+            return Config.Name?.Trim() ?? string.Empty;
         }
     }
 }

--- a/Projects/ProjectARVRPro/Process/MTF/MTFHV058/MTFHV058ProcessConfig.cs
+++ b/Projects/ProjectARVRPro/Process/MTF/MTFHV058/MTFHV058ProcessConfig.cs
@@ -8,6 +8,12 @@ namespace ProjectARVRPro.Process.MTF.MTFHV058
         public string ShowConfig { get => _ShowConfig; set { _ShowConfig = value; OnPropertyChanged(); } }
         private string _ShowConfig = "F1";
 
+        [Category("输出配置")]
+        [DisplayName("导出名称")]
+        [Description("为空时保持原有List输出；填写后作为DynamicMTFHV058TestResults的Key")]
+        public string Name { get => _Name; set { _Name = value; OnPropertyChanged(); } }
+        private string _Name = string.Empty;
+
         [Category("解析配置")]
         [DisplayName("Center_0F解析Key")]
         [Description("用于解析Center_0F数据的Key")]


### PR DESCRIPTION
## Summary

- Add `DynamicMTFHV058TestResults` to `ObjectiveTestResult` for keyed MTFHV058 output.
- Add `Name` to `MTFHV058ProcessConfig`, matching dynamic output naming used by `PoiDynamicProcess`.
- Keep existing `MTFHV058TestResults` list output when `Name` is empty, preserving deployed configurations.
- Teach CSV export and result value lookup to read keyed MTFHV058 results.

## Validation

- `dotnet build Projects/ProjectARVRPro/ProjectARVRPro.csproj`

## Notes

Legacy conversion was intentionally left unchanged.