### PR TITLE
Prepare ColorVision 1.4.10.57

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
 		<TargetFrameworks>net10.0-windows</TargetFrameworks>
 		<NoWarn>CS8002</NoWarn>
 		<AcceptNPOIOSMFLicense>true</AcceptNPOIOSMFLicense>
-		<VersionPrefix>1.4.10.56</VersionPrefix>
+		<VersionPrefix>1.4.10.57</VersionPrefix>
 		<EnableWindowsTargeting>true</EnableWindowsTargeting>
 		<CETCompat>false</CETCompat>
 	</PropertyGroup>

--- a/Engine/FlowEngineLib/Node/OLED/FormOLEDNodeProperty.cs
+++ b/Engine/FlowEngineLib/Node/OLED/FormOLEDNodeProperty.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Drawing;
+using System.Globalization;
 using System.Windows.Forms;
 using FlowEngineLib.Node.Algorithm;
 using Newtonsoft.Json;
@@ -71,26 +72,36 @@ public class FormOLEDNodeProperty : Form
 		{
 			new PointFloat
 			{
-				X = int.Parse(textBox_lefttop_x.Text),
-				Y = int.Parse(textBox_lefttop_y.Text)
+				X = ParseFloat(textBox_lefttop_x.Text),
+				Y = ParseFloat(textBox_lefttop_y.Text)
 			},
 			new PointFloat
 			{
-				X = int.Parse(textBox_righttop_x.Text),
-				Y = int.Parse(textBox_righttop_y.Text)
+				X = ParseFloat(textBox_righttop_x.Text),
+				Y = ParseFloat(textBox_righttop_y.Text)
 			},
 			new PointFloat
 			{
-				X = int.Parse(textBox_rightbottom_x.Text),
-				Y = int.Parse(textBox_rightbottom_y.Text)
+				X = ParseFloat(textBox_rightbottom_x.Text),
+				Y = ParseFloat(textBox_rightbottom_y.Text)
 			},
 			new PointFloat
 			{
-				X = int.Parse(textBox_leftbottom_x.Text),
-				Y = int.Parse(textBox_leftbottom_y.Text)
+				X = ParseFloat(textBox_leftbottom_x.Text),
+				Y = ParseFloat(textBox_leftbottom_y.Text)
 			}
 		});
 		base.DialogResult = DialogResult.OK;
+	}
+
+	private static float ParseFloat(string text)
+	{
+		if (float.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out float value) ||
+			float.TryParse(text, NumberStyles.Float, CultureInfo.CurrentCulture, out value))
+		{
+			return value;
+		}
+		return 0f;
 	}
 
 	private void button_close_Click(object sender, EventArgs e)

--- a/Engine/ST.Library.UI/NodeEditor/STNodeEditor.cs
+++ b/Engine/ST.Library.UI/NodeEditor/STNodeEditor.cs
@@ -1286,9 +1286,13 @@ public class STNodeEditor : Control
 			}
 		}
 		m_p_line_hover.Color = _HighLineColor;
-		if (m_gp_hover != null)
+		if (m_gp_hover != null && m_dic_gp_info.ContainsKey(m_gp_hover))
 		{
 			graphics.DrawPath(m_p_line_hover, m_gp_hover);
+		}
+		else
+		{
+			m_gp_hover = null;
 		}
 		m_is_buildpath = false;
 	}
@@ -1525,6 +1529,7 @@ public class STNodeEditor : Control
 
 	internal void BuildLinePath()
 	{
+		m_gp_hover = null;
 		foreach (KeyValuePair<GraphicsPath, ConnectionInfo> item in m_dic_gp_info)
 		{
 			item.Key.Dispose();

--- a/Test/ColorVision.UI.Tests/ListEditorTests.cs
+++ b/Test/ColorVision.UI.Tests/ListEditorTests.cs
@@ -1,6 +1,8 @@
 #pragma warning disable CA1707,CA1711,CA1852
 using System.ComponentModel;
+using System.Globalization;
 using ColorVision.UI.PropertyEditor.Editor.List;
+using FlowEngineLib.Node.Algorithm;
 
 namespace ColorVision.UI.Tests;
 
@@ -113,6 +115,30 @@ public class ListEditorTests
         var window = new PropertyEditorWindow(config, isEdit: true);
         Assert.NotNull(window);
         Assert.Equal(config, window.Config);
+    }
+
+    [Fact]
+    public void JsonNumericListConverter_ConvertBack_WithEnumArray_ReturnsArray()
+    {
+        var converter = new JsonNumericListConverter();
+
+        var result = Assert.IsType<TestEnum[]>(converter.ConvertBack("[0,2]", typeof(TestEnum[]), null!, CultureInfo.InvariantCulture));
+
+        Assert.Equal(new[] { TestEnum.Value1, TestEnum.Value3 }, result);
+    }
+
+    [Fact]
+    public void JsonNumericListConverter_ConvertBack_WithPointFloatArray_ReturnsArray()
+    {
+        var converter = new JsonNumericListConverter();
+
+        var result = Assert.IsType<PointFloat[]>(converter.ConvertBack("[{\"X\":1.5,\"Y\":2.25},{\"X\":3.5,\"Y\":4.25}]", typeof(PointFloat[]), null!, CultureInfo.InvariantCulture));
+
+        Assert.Equal(2, result.Length);
+        Assert.Equal(1.5f, result[0].X);
+        Assert.Equal(2.25f, result[0].Y);
+        Assert.Equal(3.5f, result[1].X);
+        Assert.Equal(4.25f, result[1].Y);
     }
 
     [Fact(Skip = RequiresStaWpfTestRunner)]

--- a/UI/ColorVision.UI/PropertyEditor/Editor/CollectionTypeHelper.cs
+++ b/UI/ColorVision.UI/PropertyEditor/Editor/CollectionTypeHelper.cs
@@ -1,0 +1,174 @@
+using ColorVision.UI;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Reflection;
+using System.Windows;
+
+namespace System.ComponentModel
+{
+    internal static class CollectionTypeHelper
+    {
+        public static bool IsSupportedCollectionType(Type type)
+        {
+            type = Nullable.GetUnderlyingType(type) ?? type;
+            if (type.IsArray)
+                return type.GetArrayRank() == 1;
+
+            if (!type.IsGenericType)
+                return false;
+
+            var genericTypeDef = type.GetGenericTypeDefinition();
+            return genericTypeDef == typeof(List<>) ||
+                   genericTypeDef == typeof(ObservableCollection<>) ||
+                   genericTypeDef == typeof(Collection<>) ||
+                   genericTypeDef == typeof(System.Collections.Generic.IList<>) ||
+                   genericTypeDef == typeof(System.Collections.Generic.ICollection<>) ||
+                   genericTypeDef == typeof(System.Collections.Generic.IEnumerable<>);
+        }
+
+        public static bool TryGetElementType(Type collectionType, out Type elementType)
+        {
+            collectionType = Nullable.GetUnderlyingType(collectionType) ?? collectionType;
+            if (collectionType.IsArray)
+            {
+                elementType = collectionType.GetElementType()!;
+                return elementType != null;
+            }
+
+            if (collectionType.IsGenericType)
+            {
+                elementType = collectionType.GetGenericArguments()[0];
+                return true;
+            }
+
+            elementType = null!;
+            return false;
+        }
+
+        public static bool IsSupportedElementType(Type type)
+        {
+            type = Nullable.GetUnderlyingType(type) ?? type;
+            if (IsSimpleElementType(type))
+                return true;
+
+            if (IsSupportedCollectionType(type) && TryGetElementType(type, out var nestedElementType))
+                return IsSupportedElementType(nestedElementType);
+
+            if (PropertyEditorHelper.GetEditorTypeForPropertyType(type) != null)
+                return true;
+
+            if (type.IsValueType)
+                return HasEditableMembers(type);
+
+            if (!type.IsClass || type.IsAbstract || typeof(Delegate).IsAssignableFrom(type) ||
+                typeof(DependencyObject).IsAssignableFrom(type) ||
+                typeof(IDictionary).IsAssignableFrom(type))
+            {
+                return false;
+            }
+
+            return type.GetConstructor(Type.EmptyTypes) != null || HasEditableMembers(type);
+        }
+
+        public static bool CanUseListDialog(Type elementType)
+        {
+            elementType = Nullable.GetUnderlyingType(elementType) ?? elementType;
+            if (IsSimpleElementType(elementType))
+                return true;
+
+            if (IsSupportedCollectionType(elementType))
+                return true;
+
+            if (PropertyEditorHelper.GetEditorTypeForPropertyType(elementType) != null)
+                return true;
+
+            return elementType.IsClass &&
+                   !elementType.IsAbstract &&
+                   typeof(Delegate).IsAssignableFrom(elementType) == false &&
+                   typeof(DependencyObject).IsAssignableFrom(elementType) == false &&
+                   typeof(IDictionary).IsAssignableFrom(elementType) == false;
+        }
+
+        public static IList? CreateEditableList(object collection, Type elementType)
+        {
+            if (collection is IList list && !list.IsFixedSize && !list.IsReadOnly)
+                return list;
+
+            if (collection is not IEnumerable enumerable)
+                return null;
+
+            var listType = typeof(List<>).MakeGenericType(elementType);
+            var editableList = (IList)Activator.CreateInstance(listType)!;
+            foreach (var item in enumerable)
+                editableList.Add(item);
+
+            return editableList;
+        }
+
+        public static object CreateEmptyCollection(Type targetType, Type elementType)
+        {
+            targetType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+            if (targetType.IsArray)
+                return Array.CreateInstance(elementType, 0);
+
+            var genericTypeDef = targetType.GetGenericTypeDefinition();
+            if (genericTypeDef == typeof(ObservableCollection<>))
+                return Activator.CreateInstance(typeof(ObservableCollection<>).MakeGenericType(elementType))!;
+
+            if (genericTypeDef == typeof(Collection<>))
+                return Activator.CreateInstance(typeof(Collection<>).MakeGenericType(elementType))!;
+
+            return Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType))!;
+        }
+
+        public static object ConvertListToDeclaredType(Type targetType, IList sourceList, Type elementType)
+        {
+            targetType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+            if (targetType.IsArray)
+            {
+                var array = Array.CreateInstance(elementType, sourceList.Count);
+                sourceList.CopyTo(array, 0);
+                return array;
+            }
+
+            if (sourceList.GetType() == targetType)
+                return sourceList;
+
+            var genericTypeDef = targetType.GetGenericTypeDefinition();
+            if (genericTypeDef == typeof(ObservableCollection<>))
+                return CopyToNewCollection(typeof(ObservableCollection<>).MakeGenericType(elementType), sourceList);
+
+            if (genericTypeDef == typeof(Collection<>))
+                return CopyToNewCollection(typeof(Collection<>).MakeGenericType(elementType), sourceList);
+
+            return sourceList;
+        }
+
+        private static object CopyToNewCollection(Type collectionType, IList sourceList)
+        {
+            var collection = (IList)Activator.CreateInstance(collectionType)!;
+            foreach (var item in sourceList)
+                collection.Add(item);
+
+            return collection;
+        }
+
+        private static bool IsSimpleElementType(Type type)
+        {
+            return type == typeof(byte) || type == typeof(sbyte) ||
+                   type == typeof(short) || type == typeof(ushort) ||
+                   type == typeof(int) || type == typeof(uint) ||
+                   type == typeof(long) || type == typeof(ulong) ||
+                   type == typeof(float) || type == typeof(double) ||
+                   type == typeof(decimal) || type == typeof(string) ||
+                   type == typeof(bool) || type.IsEnum;
+        }
+
+        private static bool HasEditableMembers(Type type)
+        {
+            return type.GetFields(BindingFlags.Public | BindingFlags.Instance).Length > 0 ||
+                   type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                       .Any(p => p.CanRead && p.CanWrite && p.GetIndexParameters().Length == 0);
+        }
+    }
+}

--- a/UI/ColorVision.UI/PropertyEditor/Editor/JsonNumericListConverter.cs
+++ b/UI/ColorVision.UI/PropertyEditor/Editor/JsonNumericListConverter.cs
@@ -2,7 +2,6 @@ using ColorVision.UI;
 using ColorVision.UI.PropertyEditor.Editor.List;
 using Newtonsoft.Json;
 using System.Collections;
-using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Reflection;
 using System.Windows;
@@ -10,28 +9,17 @@ using System.Windows.Controls;
 using System.Windows.Data;
 
 namespace System.ComponentModel
-{    
-    // 通用：为所有支持的集合类型注册 JSON 文本编辑器（List<T>、ObservableCollection<T>、Collection<T> 等）
-    public class ListNumericJsonEditor : IPropertyEditor
+{
+    public class CollectionJsonEditor : IPropertyEditor
     {
-        static ListNumericJsonEditor()
+        static CollectionJsonEditor()
         {
-            // 通过谓词一次性注册：匹配支持的集合类型
-            PropertyEditorHelper.RegisterEditor<ListNumericJsonEditor>(t =>
+            PropertyEditorHelper.RegisterEditor<CollectionJsonEditor>(t =>
             {
                 t = Nullable.GetUnderlyingType(t) ?? t;
-                if (!t.IsGenericType)
-                    return false;
-                
-                var genericTypeDef = t.GetGenericTypeDefinition();
-                
-                // 支持 List<T>, ObservableCollection<T>, Collection<T>, IList<T>, ICollection<T>, IEnumerable<T>
-                return genericTypeDef == typeof(System.Collections.Generic.List<>) ||
-                       genericTypeDef == typeof(ObservableCollection<>) ||
-                       genericTypeDef == typeof(Collection<>) ||
-                       genericTypeDef == typeof(System.Collections.Generic.IList<>) ||
-                       genericTypeDef == typeof(System.Collections.Generic.ICollection<>) ||
-                       genericTypeDef == typeof(System.Collections.Generic.IEnumerable<>);
+                return CollectionTypeHelper.IsSupportedCollectionType(t) &&
+                       CollectionTypeHelper.TryGetElementType(t, out var elementType) &&
+                       CollectionTypeHelper.IsSupportedElementType(elementType);
             });
         }
 
@@ -39,280 +27,113 @@ namespace System.ComponentModel
         {
             var rm = PropertyEditorHelper.GetResourceManager(obj);
             var dockPanel = new DockPanel();
-
-            var label = PropertyEditorHelper.CreateLabel(property, rm);
-            dockPanel.Children.Add(label);
+            dockPanel.Children.Add(PropertyEditorHelper.CreateLabel(property, rm));
 
             var binding = new Binding(property.Name)
             {
                 Source = obj,
                 Mode = BindingMode.TwoWay,
-                // JSON 在输入过程中容易“半成品”，建议失焦再提交，避免每击键即报错
                 UpdateSourceTrigger = UpdateSourceTrigger.LostFocus,
-                Converter = new JsonNumericListConverter(),
+                Converter = new CollectionJsonValueConverter(),
                 ValidatesOnExceptions = true,
-                NotifyOnValidationError = true,
+                NotifyOnValidationError = true
             };
 
             var textBox = PropertyEditorHelper.CreateSmallTextBox(binding);
             textBox.ToolTip = "输入 JSON 数组，例如: [1, 2, 3]";
             textBox.PreviewKeyDown += PropertyEditorHelper.TextBox_PreviewKeyDown;
 
-            // 添加编辑按钮
+            if (CollectionTypeHelper.TryGetElementType(property.PropertyType, out var elementType) &&
+                CollectionTypeHelper.CanUseListDialog(elementType))
+            {
+                var editButton = CreateEditButton(property, obj, dockPanel, textBox, elementType);
+                DockPanel.SetDock(editButton, Dock.Right);
+                dockPanel.Children.Add(editButton);
+            }
+
+            dockPanel.Children.Add(textBox);
+            return dockPanel;
+        }
+
+        private static Button CreateEditButton(PropertyInfo property, object obj, DockPanel dockPanel, TextBox textBox, Type elementType)
+        {
             var editButton = new Button
             {
                 Content = ColorVision.UI.Properties.Resources.Edit,
                 Margin = new Thickness(5, 0, 0, 0),
                 MinWidth = 60
             };
-            editButton.Click += (s, e) =>
+
+            editButton.Click += (_, _) =>
             {
-                // 获取集合实例
                 var collection = property.GetValue(obj);
-                if (collection != null)
+                if (collection == null)
+                    return;
+
+                var list = CollectionTypeHelper.CreateEditableList(collection, elementType);
+                if (list == null)
+                    return;
+
+                var collectionEditorAttr = property.GetCustomAttribute<CollectionEditorTypeAttribute>();
+                var editorWindow = new ListEditorWindow(list, elementType, collectionEditorAttr?.ItemEditorType)
                 {
-                    // 确保集合实现了 IList 接口（用于可修改的集合）
-                    IList? list = null;
-                    
-                    if (collection is IList ilist)
-                    {
-                        list = ilist;
-                    }
-                    else if (collection is System.Collections.IEnumerable enumerable)
-                    {
-                        // 对于只读集合（如 IEnumerable），创建临时 List 用于编辑
-                        var elementType = property.PropertyType.GetGenericArguments()[0];
-                        var listType = typeof(List<>).MakeGenericType(elementType);
-                        list = (IList)Activator.CreateInstance(listType)!;
-                        foreach (var item in enumerable)
-                        {
-                            list.Add(item);
-                        }
-                    }
-                    
-                    if (list != null)
-                    {
-                        var elementType = property.PropertyType.GetGenericArguments()[0];
-                        var collectionEditorAttr = property.GetCustomAttribute<CollectionEditorTypeAttribute>();
-                        var editorWindow = new ListEditorWindow(list, elementType, collectionEditorAttr?.ItemEditorType);
-                        editorWindow.Owner = Window.GetWindow(dockPanel);
-                        
-                        if (editorWindow.ShowDialog() == true)
-                        {
-                            // 如果原集合不是 IList，需要重新创建集合并赋值
-                            if (collection is not IList)
-                            {
-                                var newCollection = CreateCollectionFromList(property.PropertyType, list, elementType);
-                                property.SetValue(obj, newCollection);
-                            }
-                            
-                            // 更新 TextBox 显示
-                            textBox.GetBindingExpression(TextBox.TextProperty)?.UpdateTarget();
-                        }
-                    }
+                    Owner = Window.GetWindow(dockPanel)
+                };
+
+                if (editorWindow.ShowDialog() == true)
+                {
+                    property.SetValue(obj, CollectionTypeHelper.ConvertListToDeclaredType(property.PropertyType, list, elementType));
+                    textBox.GetBindingExpression(TextBox.TextProperty)?.UpdateTarget();
                 }
             };
 
-            DockPanel.SetDock(editButton, Dock.Right);
-            dockPanel.Children.Add(editButton);
-            dockPanel.Children.Add(textBox);
-            return dockPanel;
-        }
-        
-        private static object CreateCollectionFromList(Type targetType, IList list, Type elementType)
-        {
-            var genericTypeDef = targetType.GetGenericTypeDefinition();
-            
-            if (genericTypeDef == typeof(ObservableCollection<>))
-            {
-                var obsCollType = typeof(ObservableCollection<>).MakeGenericType(elementType);
-                var obsColl = (IList)Activator.CreateInstance(obsCollType)!;
-                foreach (var item in list)
-                    obsColl.Add(item);
-                return obsColl;
-            }
-            else if (genericTypeDef == typeof(Collection<>))
-            {
-                var collType = typeof(Collection<>).MakeGenericType(elementType);
-                var coll = (IList)Activator.CreateInstance(collType)!;
-                foreach (var item in list)
-                    coll.Add(item);
-                return coll;
-            }
-            else if (genericTypeDef == typeof(System.Collections.Generic.IList<>) ||
-                     genericTypeDef == typeof(System.Collections.Generic.ICollection<>) ||
-                     genericTypeDef == typeof(System.Collections.Generic.IEnumerable<>))
-            {
-                // For interfaces, return a List<T>
-                return list;
-            }
-            
-            return list;
+            return editButton;
         }
     }
 
-
-    public class JsonNumericListConverter : IValueConverter
+    public class CollectionJsonValueConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is System.Collections.IEnumerable enumerable)
-            {
-                // 将任意 List<T> 序列化为 JSON
-                return JsonConvert.SerializeObject(value, Formatting.None);
-            }
-            // 空列表显示为 []
-            return "[]";
+            return value is IEnumerable ? JsonConvert.SerializeObject(value, Formatting.None) : "[]";
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var s = value?.ToString();
+            var text = value?.ToString();
+            if (!CollectionTypeHelper.IsSupportedCollectionType(targetType))
+                throw new NotSupportedException($"Collection type {targetType} is not supported. Supported types: arrays, List<T>, ObservableCollection<T>, Collection<T>, IList<T>, ICollection<T>, IEnumerable<T>.");
 
-            // 目标必须是支持的集合类型
-            if (!IsSupportedCollectionType(targetType))
-                throw new NotSupportedException($"Collection type {targetType} is not supported. Supported types: List<T>, ObservableCollection<T>, Collection<T>, IList<T>, ICollection<T>, IEnumerable<T>.");
+            if (!CollectionTypeHelper.TryGetElementType(targetType, out var elementType))
+                throw new NotSupportedException($"Collection type {targetType} is missing an element type.");
 
-            var elemType = targetType.GetGenericArguments()[0];
-            if (!IsSupportedElementType(elemType))
-                throw new NotSupportedException($"Element type {elemType} is not supported. Supported element types: numeric types, string, enum, nested collections, or editable configuration classes.");
+            if (!CollectionTypeHelper.IsSupportedElementType(elementType))
+                throw new NotSupportedException($"Element type {elementType} is not supported. Supported element types: numeric types, string, enum, nested collections, simple structs, or editable configuration classes.");
 
-            if (string.IsNullOrWhiteSpace(s))
-            {
-                // 空输入 -> 空集合
-                return CreateEmptyCollection(targetType, elemType);
-            }
+            if (string.IsNullOrWhiteSpace(text))
+                return CollectionTypeHelper.CreateEmptyCollection(targetType, elementType);
 
             try
             {
-                // 先反序列化为 List<T>
-                var concreteListType = typeof(List<>).MakeGenericType(elemType);
-                var result = JsonConvert.DeserializeObject(s, concreteListType);
-                
-                if (result == null)
-                    return CreateEmptyCollection(targetType, elemType);
+                var listType = typeof(List<>).MakeGenericType(elementType);
+                var result = JsonConvert.DeserializeObject(text, listType);
+                if (result is not IList list)
+                    return CollectionTypeHelper.CreateEmptyCollection(targetType, elementType);
 
-                // 转换为目标集合类型
-                return ConvertToTargetCollection(result as IList, targetType, elemType);
+                return CollectionTypeHelper.ConvertListToDeclaredType(targetType, list, elementType);
             }
-            catch (Exception)
+            catch
             {
-                // 触发 WPF 校验错误显示
-                throw new FormatException($"JSON 格式不正确，示例: [1, 2, 3]");
+                throw new FormatException("JSON 格式不正确，示例: [1, 2, 3]");
             }
         }
+    }
 
-        private static bool IsSupportedCollectionType(Type t)
-        {
-            if (!t.IsGenericType)
-                return false;
-                
-            var genericTypeDef = t.GetGenericTypeDefinition();
-            return genericTypeDef == typeof(List<>) ||
-                   genericTypeDef == typeof(ObservableCollection<>) ||
-                   genericTypeDef == typeof(Collection<>) ||
-                   genericTypeDef == typeof(System.Collections.Generic.IList<>) ||
-                   genericTypeDef == typeof(System.Collections.Generic.ICollection<>) ||
-                   genericTypeDef == typeof(System.Collections.Generic.IEnumerable<>);
-        }
+    public class ListNumericJsonEditor : CollectionJsonEditor
+    {
+    }
 
-        private static object CreateEmptyCollection(Type targetType, Type elementType)
-        {
-            var genericTypeDef = targetType.GetGenericTypeDefinition();
-            
-            if (genericTypeDef == typeof(ObservableCollection<>))
-            {
-                return Activator.CreateInstance(typeof(ObservableCollection<>).MakeGenericType(elementType))!;
-            }
-            else if (genericTypeDef == typeof(Collection<>))
-            {
-                return Activator.CreateInstance(typeof(Collection<>).MakeGenericType(elementType))!;
-            }
-            else if (genericTypeDef == typeof(System.Collections.Generic.IList<>) ||
-                     genericTypeDef == typeof(System.Collections.Generic.ICollection<>) ||
-                     genericTypeDef == typeof(System.Collections.Generic.IEnumerable<>))
-            {
-                // For interfaces, return a List<T>
-                return Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType))!;
-            }
-            
-            // Default to List<T>
-            return Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType))!;
-        }
-
-        private static object ConvertToTargetCollection(IList? sourceList, Type targetType, Type elementType)
-        {
-            if (sourceList == null)
-                return CreateEmptyCollection(targetType, elementType);
-                
-            var genericTypeDef = targetType.GetGenericTypeDefinition();
-            
-            // If target is already the source type, return as-is
-            if (sourceList.GetType() == targetType)
-                return sourceList;
-            
-            if (genericTypeDef == typeof(ObservableCollection<>))
-            {
-                var obsCollType = typeof(ObservableCollection<>).MakeGenericType(elementType);
-                var obsColl = (IList)Activator.CreateInstance(obsCollType)!;
-                foreach (var item in sourceList)
-                    obsColl.Add(item);
-                return obsColl;
-            }
-            else if (genericTypeDef == typeof(Collection<>))
-            {
-                var collType = typeof(Collection<>).MakeGenericType(elementType);
-                var coll = (IList)Activator.CreateInstance(collType)!;
-                foreach (var item in sourceList)
-                    coll.Add(item);
-                return coll;
-            }
-            else if (genericTypeDef == typeof(System.Collections.Generic.IList<>) ||
-                     genericTypeDef == typeof(System.Collections.Generic.ICollection<>) ||
-                     genericTypeDef == typeof(System.Collections.Generic.IEnumerable<>))
-            {
-                // For interfaces, return the List<T>
-                return sourceList;
-            }
-            
-            // Default: return the List<T> 
-            return sourceList;
-        }
-
-        private static bool IsSupportedElementType(Type t)
-        {
-            t = Nullable.GetUnderlyingType(t) ?? t;
-            if (t == typeof(byte) || t == typeof(sbyte) ||
-                t == typeof(short) || t == typeof(ushort) ||
-                t == typeof(int) || t == typeof(uint) ||
-                t == typeof(long) || t == typeof(ulong) ||
-                t == typeof(float) || t == typeof(double) ||
-                t == typeof(decimal) || t == typeof(string) ||
-                t == typeof(bool) || t.IsEnum)
-            {
-                return true;
-            }
-
-            if (IsSupportedCollectionType(t))
-            {
-                return IsSupportedElementType(t.GetGenericArguments()[0]);
-            }
-
-            if (PropertyEditorHelper.GetEditorTypeForPropertyType(t) != null)
-            {
-                return true;
-            }
-
-            if (!t.IsClass || t.IsAbstract || typeof(Delegate).IsAssignableFrom(t) ||
-                typeof(System.Windows.DependencyObject).IsAssignableFrom(t) ||
-                typeof(System.Collections.IDictionary).IsAssignableFrom(t))
-            {
-                return false;
-            }
-
-            return t.GetConstructor(Type.EmptyTypes) != null ||
-                   t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                       .Any(p => p.CanRead && p.CanWrite && p.GetIndexParameters().Length == 0);
-        }
+    public class JsonNumericListConverter : CollectionJsonValueConverter
+    {
     }
 }


### PR DESCRIPTION
## Summary
- Fix intermittent `Graphics.DrawPath` crash in `STNodeEditor` by clearing stale disposed hover paths when connection paths are rebuilt.
- Improve collection JSON editing support for arrays and common collection types while keeping existing editor/converter aliases compatible.
- Parse OLED point coordinates as floats and add focused list editor tests.
- Bump `VersionPrefix` to `1.4.10.57`.

## Validation
- `dotnet build Engine\ST.Library.UI\ST.Library.UI.csproj -f net10.0-windows`
- `dotnet build Engine\ST.Library.UI\ST.Library.UI.csproj -f net8.0-windows`
- `dotnet build Engine\FlowEngineLib\FlowEngineLib.csproj -f net10.0-windows`
- `dotnet build UI\ColorVision.UI\ColorVision.UI.csproj -f net10.0-windows7.0`
- `dotnet test Test\ColorVision.UI.Tests\ColorVision.UI.Tests.csproj --filter "FullyQualifiedName~ListEditorTests"`
- `Scripts\release.bat` completed: installer, changelog, latest marker, and update package uploaded.

## Release Artifacts
- Installer: `C:\Users\17917\Documents\Advanced Installer\Projects\ColorVision\Setup Files\ColorVision-1.4.10.57.exe`
- Update package: `C:\Users\17917\Desktop\History\update\ColorVision-Update-[1.4.10.57].cvx`
- Release log: `C:\Users\17917\Desktop\scgd_general_wpf\ReleaseLogs\codex-release-20260708-150313.log`